### PR TITLE
feat: use flags instead of positional args

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ spec:
     args:
       - --node=$(NODE)
       - --tag=$(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)
-      # - --powercycle # Optional
+      # - --powercycle # Optional, Talos reboots via the kexec syscall by default
 ```
 
 Talos Node Updater needs a service account that can access the Talos API and read `Node` resources.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ spec:
     args:
       - --node=$(NODE)
       - --tag=$(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)
+      # - --powercycle # Optional
 ```
 
 Talos Node Updater needs a service account that can access the Talos API and read `Node` resources.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ spec:
           fieldRef:
             fieldPath: spec.nodeName
     args:
-      - $(NODE)
-      - $(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)
+      - --node=$(NODE)
+      - --tag=$(SYSTEM_UPGRADE_PLAN_LATEST_VERSION)
 ```
 
 Talos Node Updater needs a service account that can access the Talos API and read `Node` resources.


### PR DESCRIPTION
Hi 👋🏼 

Instead of using positional args, lets use flags. I also updated the `--reboot-mode` flag to be a bool called `--powercycle`. By default kexec reboot is used.

``` tnu --node <nodeName> --tag <imageTag> --powercycle```